### PR TITLE
#31 fix for parent class fields

### DIFF
--- a/src/main/java/io/lenar/easy/log/support/Processor.java
+++ b/src/main/java/io/lenar/easy/log/support/Processor.java
@@ -3,6 +3,7 @@ package io.lenar.easy.log.support;
 import static io.lenar.easy.log.support.Processor.ObjectType.*;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,8 +49,7 @@ public class Processor {
         return list;
     }
 
-    private static Map<String, Object> objectAsMap(Object obj)
-    {
+    private static Map<String, Object> objectAsMap(Object obj) {
         Class<? extends Object> clazz = obj.getClass();
         Map<String, Object> map = new HashMap<>();
         map = objectAsMapWithParents(clazz, obj, map);
@@ -59,13 +59,15 @@ public class Processor {
     private static Map<String, Object> objectAsMapWithParents(Class clazz, Object obj, Map<String, Object> subMap) {
         try {
             Field[] fields = clazz.getDeclaredFields();
-            debug("OBJECT TO MAP: " + obj.toString());
+            debug("Class: " + clazz.getSimpleName());
             for (int i = 0; i < fields.length; i++) {
-                String name = fields[i].getName();
-                if (!subMap.containsKey(name)){
-                    fields[i].setAccessible(true);
-                    Object value = fields[i].get(obj);
-                    subMap.put(name, value);
+                if (!Modifier.isProtected(fields[i].getModifiers())) {
+                    String name = fields[i].getName();
+                    if (!subMap.containsKey(name)) {
+                        fields[i].setAccessible(true);
+                        Object value = fields[i].get(obj);
+                        subMap.put(name, value);
+                    }
                 }
             }
             Class superClazz = clazz.getSuperclass();

--- a/src/main/java/io/lenar/easy/log/support/Processor.java
+++ b/src/main/java/io/lenar/easy/log/support/Processor.java
@@ -56,28 +56,28 @@ public class Processor {
         return map;
     }
 
-    private static Map<String, Object> objectAsMapWithParents(Class clazz, Object obj, Map<String, Object> subMap) {
+    private static Map<String, Object> objectAsMapWithParents(Class clazz, Object obj, Map<String, Object> map) {
         try {
             Field[] fields = clazz.getDeclaredFields();
             debug("Class: " + clazz.getSimpleName());
             for (int i = 0; i < fields.length; i++) {
                 if (!Modifier.isProtected(fields[i].getModifiers())) {
                     String name = fields[i].getName();
-                    if (!subMap.containsKey(name)) {
+                    if (!map.containsKey(name)) {
                         fields[i].setAccessible(true);
                         Object value = fields[i].get(obj);
-                        subMap.put(name, value);
+                        map.put(name, value);
                     }
                 }
             }
             Class superClazz = clazz.getSuperclass();
             if (superClazz != null) {
-                subMap = objectAsMapWithParents(superClazz, obj, subMap);
+                map = objectAsMapWithParents(superClazz, obj, map);
             }
         } catch (Exception ex) {
-            subMap.put("LOGGING_ERROR", "Failed to log object");
+            map.put("LOGGING_ERROR", "Failed to log object");
         }
-        return subMap;
+        return map;
     }
 
     private static Object processMap(Map<String, Object> map, String[] maskFields) {


### PR DESCRIPTION
Tested for the classes in #31 
Log output:
```
11:38:21.937 [main] INFO  UneasyLogger - 
CLIENT
-> public MySubClass Client.myMethod(MySubClass mySubClass)
mySubClass: {
  "mySubClassPrivateField": "mySubClassPrivateField",
  "mySubClassProtectedField": "mySubClassProtectedField",
  "mySubClassPublicField": "mySubClassPublicField",
  "myClassProtectedField": "myClassProtectedField",
  "myClassPrivateField": "myClassPrivateField",
  "myClassPublicField": "myClassPublicField"
}


11:38:21.947 [main] INFO  UneasyLogger - 
Execution/Response time:  10ms
CLIENT
<- MySubClass Client.myMethod(MySubClass mySubClass)
{
  "mySubClassPrivateField": "mySubClassPrivateField",
  "mySubClassProtectedField": "mySubClassProtectedField",
  "mySubClassPublicField": "mySubClassPublicField",
  "myClassProtectedField": "myClassProtectedField",
  "myClassPrivateField": "myClassPrivateField",
  "myClassPublicField": "myClassPublicField"
}
```

YAY!